### PR TITLE
refactor interfaces name, deleted remove

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/CategoryController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoryController.java
@@ -3,7 +3,7 @@ package com.alkemy.ong.controller;
 import com.alkemy.ong.model.request.CategoryDto;
 import com.alkemy.ong.model.entity.Category;
 import com.alkemy.ong.service.CategoryServiceImpl;
-import com.alkemy.ong.service.abstraction.IDeleteCategoryService;
+import com.alkemy.ong.service.abstraction.ICategoryService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +21,14 @@ import java.util.List;
 public class CategoryController {
 
     @Autowired
-    private IDeleteCategoryService deleteCategoryService;
+    private ICategoryService CategoryService;
 
     @Autowired
     private CategoryServiceImpl categoryService;
 
     @DeleteMapping(value = "/categories/{id}")
     public ResponseEntity<Empty> delete(@PathVariable long id) throws EntityNotFoundException {
-        deleteCategoryService.delete(id);
+        CategoryService.delete(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/alkemy/ong/controller/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentController.java
@@ -1,7 +1,7 @@
 package com.alkemy.ong.controller;
 
 import com.alkemy.ong.exception.OperationNotAllowedException;
-import com.alkemy.ong.service.abstraction.IDeleteCommentsService;
+import com.alkemy.ong.service.abstraction.ICommentsService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
   @Autowired
-  private IDeleteCommentsService deleteCommentsService;
+  private ICommentsService CommentsService;
 
   @DeleteMapping(value = "/comments/{id}")
   public ResponseEntity<Empty> delete(@PathVariable("id") long id,
       @RequestHeader(value = "Authorization") String authorizationHeader)
       throws OperationNotAllowedException {
-    deleteCommentsService.delete(id, authorizationHeader);
+    CommentsService.delete(id, authorizationHeader);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.controller;
 
-import com.alkemy.ong.service.abstraction.IDeleteMembersService;
+import com.alkemy.ong.service.abstraction.IMembersService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
   @Autowired
-  private IDeleteMembersService deleteMembersService;
+  private IMembersService MembersService;
 
   @DeleteMapping(value = "/members/{id}")
   public ResponseEntity<Empty> delete(@PathVariable long id) throws EntityNotFoundException {
-    deleteMembersService.delete(id);
+    MembersService.delete(id);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/com/alkemy/ong/controller/SlideController.java
+++ b/src/main/java/com/alkemy/ong/controller/SlideController.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.controller;
 
-import com.alkemy.ong.service.abstraction.IDeleteSlideService;
+import com.alkemy.ong.service.abstraction.ISlideService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SlideController {
 
   @Autowired
-  private IDeleteSlideService deleteSlideService;
+  private ISlideService SlideService;
 
   @DeleteMapping(value = "/slides/{id}")
   public ResponseEntity<Empty> delete(@PathVariable("id") long id) throws EntityNotFoundException {
-    deleteSlideService.delete(id);
+    SlideService.delete(id);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.controller;
 
-import com.alkemy.ong.service.abstraction.IDeleteTestimonialService;
+import com.alkemy.ong.service.abstraction.ITestimonialService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestimonialController {
 
   @Autowired
-  private IDeleteTestimonialService deleteTestimonialService;
+  private ITestimonialService TestimonialService;
 
   @DeleteMapping(value = "/testimonials/{id}")
   public ResponseEntity<Empty> delete(@PathVariable Long id) throws EntityNotFoundException {
-    deleteTestimonialService.delete(id);
+    TestimonialService.delete(id);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/com/alkemy/ong/controller/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.controller;
 
 import com.alkemy.ong.dto.UserDto;
-import com.alkemy.ong.service.abstraction.IDeleteUserService;
 import com.alkemy.ong.service.abstraction.IUserService;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext.Empty;
 import javax.persistence.EntityNotFoundException;
@@ -14,9 +13,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
   @Autowired
-  public IDeleteUserService deleteUserService;
-
-  @Autowired
   public IUserService userService;
 
   @PostMapping("/auth/register")
@@ -27,7 +23,7 @@ public class UserController {
 
   @DeleteMapping(value = "/users/{id}")
   public ResponseEntity<Empty> delete(@PathVariable Long id) throws EntityNotFoundException {
-    deleteUserService.delete(id);
+    userService.delete(id);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/com/alkemy/ong/service/CategoryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/CategoryServiceImpl.java
@@ -4,8 +4,8 @@ import com.alkemy.ong.mapper.CategoryMapper;
 import com.alkemy.ong.model.entity.Category;
 import com.alkemy.ong.model.request.CategoryDto;
 import com.alkemy.ong.repository.ICategoryRepository;
-import com.alkemy.ong.service.abstraction.IDeleteCategoryService;
-import java.util.ArrayList;
+import com.alkemy.ong.service.abstraction.ICategoryService;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CategoryServiceImpl implements IDeleteCategoryService {
+public class CategoryServiceImpl implements ICategoryService {
 
     private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found.";
 

--- a/src/main/java/com/alkemy/ong/service/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/CommentServiceImpl.java
@@ -6,7 +6,7 @@ import com.alkemy.ong.model.entity.Comment;
 import com.alkemy.ong.model.entity.Role;
 import com.alkemy.ong.model.entity.User;
 import com.alkemy.ong.repository.ICommentRepository;
-import com.alkemy.ong.service.abstraction.IDeleteCommentsService;
+import com.alkemy.ong.service.abstraction.ICommentsService;
 import com.alkemy.ong.service.abstraction.IGetUserService;
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CommentServiceImpl implements IDeleteCommentsService {
+public class CommentServiceImpl implements ICommentsService {
 
   private static final String COMMENT_NOT_FOUND_MESSAGE = "Comment not found.";
   private static final String USER_IS_NOT_ABLE_TO_DELETE_COMMENT_MESSAGE = "User is not able to delete comment.";

--- a/src/main/java/com/alkemy/ong/service/MemberServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/MemberServiceImpl.java
@@ -2,14 +2,14 @@ package com.alkemy.ong.service;
 
 import com.alkemy.ong.model.entity.Member;
 import com.alkemy.ong.repository.IMemberRepository;
-import com.alkemy.ong.service.abstraction.IDeleteMembersService;
+import com.alkemy.ong.service.abstraction.IMembersService;
 import java.util.Optional;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MemberServiceImpl implements IDeleteMembersService {
+public class MemberServiceImpl implements IMembersService {
 
   private static final String MEMBER_NOT_FOUND_MESSAGE = "Member not found.";
 

--- a/src/main/java/com/alkemy/ong/service/SlideServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/SlideServiceImpl.java
@@ -1,13 +1,13 @@
 package com.alkemy.ong.service;
 
 import com.alkemy.ong.repository.ISlideRepository;
-import com.alkemy.ong.service.abstraction.IDeleteSlideService;
+import com.alkemy.ong.service.abstraction.ISlideService;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class SlideServiceImpl implements IDeleteSlideService {
+public class SlideServiceImpl implements ISlideService {
 
   private static final String SLIDE_NOT_FOUND_MESSAGE = "Slide not found.";
 

--- a/src/main/java/com/alkemy/ong/service/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialServiceImpl.java
@@ -2,14 +2,14 @@ package com.alkemy.ong.service;
 
 import com.alkemy.ong.model.entity.Testimonial;
 import com.alkemy.ong.repository.ITestimonialRepository;
-import com.alkemy.ong.service.abstraction.IDeleteTestimonialService;
+import com.alkemy.ong.service.abstraction.ITestimonialService;
 import java.util.Optional;
 import javax.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TestimonialServiceImpl implements IDeleteTestimonialService {
+public class TestimonialServiceImpl implements ITestimonialService {
 
   private static final String TESTIMONIAL_NOT_FOUND_MESSAGE = "Testimonial not found.";
 

--- a/src/main/java/com/alkemy/ong/service/UserServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/UserServiceImpl.java
@@ -5,7 +5,6 @@ import com.alkemy.ong.mapper.UserMapper;
 import com.alkemy.ong.model.entity.User;
 import com.alkemy.ong.dto.UserDto;
 import com.alkemy.ong.repository.IUserRepository;
-import com.alkemy.ong.service.abstraction.IDeleteUserService;
 import com.alkemy.ong.service.abstraction.IGetUserService;
 import java.util.Optional;
 import javax.persistence.EntityNotFoundException;
@@ -19,7 +18,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserServiceImpl implements UserDetailsService, IDeleteUserService, IGetUserService, IUserService {
+public class UserServiceImpl implements UserDetailsService, IGetUserService, IUserService {
 
   private static final String USER_NOT_FOUND_MESSAGE = "User not found.";
 

--- a/src/main/java/com/alkemy/ong/service/abstraction/ICategoryService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/ICategoryService.java
@@ -2,7 +2,7 @@ package com.alkemy.ong.service.abstraction;
 
 import javax.persistence.EntityNotFoundException;
 
-public interface IDeleteMembersService {
+public interface ICategoryService {
 
   void delete(Long id) throws EntityNotFoundException;
 

--- a/src/main/java/com/alkemy/ong/service/abstraction/ICommentsService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/ICommentsService.java
@@ -2,7 +2,7 @@ package com.alkemy.ong.service.abstraction;
 
 import com.alkemy.ong.exception.OperationNotAllowedException;
 
-public interface IDeleteCommentsService {
+public interface ICommentsService {
 
   void delete(Long id, String authorizationHeader) throws OperationNotAllowedException;
 

--- a/src/main/java/com/alkemy/ong/service/abstraction/IDeleteUserService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/IDeleteUserService.java
@@ -1,9 +1,0 @@
-package com.alkemy.ong.service.abstraction;
-
-import javax.persistence.EntityNotFoundException;
-
-public interface IDeleteUserService {
-
-  void delete(Long id) throws EntityNotFoundException;
-
-}

--- a/src/main/java/com/alkemy/ong/service/abstraction/IMembersService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/IMembersService.java
@@ -2,7 +2,7 @@ package com.alkemy.ong.service.abstraction;
 
 import javax.persistence.EntityNotFoundException;
 
-public interface IDeleteCategoryService {
+public interface IMembersService {
 
   void delete(Long id) throws EntityNotFoundException;
 

--- a/src/main/java/com/alkemy/ong/service/abstraction/ISlideService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/ISlideService.java
@@ -2,7 +2,8 @@ package com.alkemy.ong.service.abstraction;
 
 import javax.persistence.EntityNotFoundException;
 
-public interface IDeleteTestimonialService {
+public interface ISlideService {
 
   void delete(Long id) throws EntityNotFoundException;
+
 }

--- a/src/main/java/com/alkemy/ong/service/abstraction/ITestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/ITestimonialService.java
@@ -2,8 +2,7 @@ package com.alkemy.ong.service.abstraction;
 
 import javax.persistence.EntityNotFoundException;
 
-public interface IDeleteSlideService {
+public interface ITestimonialService {
 
   void delete(Long id) throws EntityNotFoundException;
-
 }

--- a/src/main/java/com/alkemy/ong/service/abstraction/IUserService.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/IUserService.java
@@ -2,7 +2,12 @@ package com.alkemy.ong.service.abstraction;
 
 import com.alkemy.ong.dto.UserDto;
 
+import javax.persistence.EntityNotFoundException;
+
 public interface IUserService {
 
     UserDto save(UserDto userRequestDto);
+
+    void delete(Long id) throws EntityNotFoundException;
+
 }


### PR DESCRIPTION
variable renaming, deteled remove

IDeletedUserService removed, we keep IUserService

Renombramos interfaces para remover palabra "delete", renombramos variables usadas en implentaciones y controladores removiendo la palabra "delete", eliminamos interface IDeleteUserService porque ya existia IUserService la cual mantuvimos y pusimos el metodo delete ahi mismo. Elimine inyeccion IDeleteUserService en UserController mantuve IUserService.


![pr change interfaces name](https://user-images.githubusercontent.com/54560646/147016921-129b9188-420f-486e-b66d-c15071a3eb0b.png)

